### PR TITLE
Implement Send for UniqueRc

### DIFF
--- a/src/unique.rs
+++ b/src/unique.rs
@@ -76,6 +76,10 @@ impl<T> From<UniqueRc<T>> for Pin<UniqueRc<T>> {
 // over the Rc's non-atomic reference counts.
 unsafe impl<T: Send> Send for UniqueRc<T> {}
 
+// SAFETY: The underlying `Rc` cannot be cloned or dropped while the `UniqueRc` exists, so
+// there is no possibility of data races over its non-atomic reference counts.
+unsafe impl<T: Sync> Sync for UniqueRc<T> {}
+
 /// An uniquely owned `Arc`.
 ///
 /// Useful for constructing `Arc`, since we are certain that when `Arc` is

--- a/src/unique.rs
+++ b/src/unique.rs
@@ -72,6 +72,10 @@ impl<T> From<UniqueRc<T>> for Pin<UniqueRc<T>> {
     }
 }
 
+// SAFETY: We know this is uniquely owned, so there is no possibility of data races
+// over the Rc's non-atomic reference counts.
+unsafe impl<T: Send> Send for UniqueRc<T> {}
+
 /// An uniquely owned `Arc`.
 ///
 /// Useful for constructing `Arc`, since we are certain that when `Arc` is


### PR DESCRIPTION
Since UniqueRc is uniquely owned, there is no possibility of data races over the its non-atomic reference counts.  Therefore, it is safe to send to another thread (as long as its contents are also `Send`).