### PR TITLE
Clean compiler and cargo warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ default = ["alloc", "alloc_pin_with"]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "doc_cfg"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -89,7 +89,10 @@ struct Mutex<T> {
 unsafe impl<T: Send> Send for Mutex<T> {}
 unsafe impl<T: Send> Sync for Mutex<T> {}
 
-struct MutexGuard<'a, T>(RawMutexGuard<'a>, &'a mut T);
+struct MutexGuard<'a, T>(
+    #[allow(dead_code)]
+    RawMutexGuard<'a>,
+    &'a mut T);
 
 impl<'a, T> Deref for MutexGuard<'a, T> {
     type Target = T;

--- a/pin-init-internal/Cargo.toml
+++ b/pin-init-internal/Cargo.toml
@@ -10,7 +10,7 @@ Internal implementation details of crate `pin_init`.
 """
 
 [lib]
-proc_macro = true
+proc-macro = true
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
There are two warnings when building trunk with latest rustc and Cargo, fix them:
* allow dead_code when the field is unused but needed for its Drop implementation
* use modern spelling of lib.proc_macro in Cargo.toml.