### PR TITLE
port to syn 2.0

### DIFF
--- a/pin-init-internal/Cargo.toml
+++ b/pin-init-internal/Cargo.toml
@@ -13,6 +13,6 @@ Internal implementation details of crate `pin_init`.
 proc_macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/pin-init-internal/src/pin_init.rs
+++ b/pin-init-internal/src/pin_init.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::{
     punctuated::Punctuated, visit_mut, visit_mut::VisitMut, Attribute, Data, DeriveInput, Error,
-    Expr, ExprCall, ExprPath, Fields, GenericParam, Generics, ItemStruct, LifetimeDef, Member,
+    Expr, ExprCall, ExprPath, Fields, GenericParam, Generics, ItemStruct, Member,
     Result, TraitBound, TraitBoundModifier, TypeParamBound,
 };
 
@@ -54,7 +54,7 @@ pub fn pin_init_derive(input: TokenStream) -> Result<TokenStream> {
         .map(|field| {
             let mut has_pin = false;
             field.attrs.retain(|a| {
-                if a.path.is_ident("pin") {
+                if a.path().is_ident("pin") {
                     has_pin = true;
                     false
                 } else {
@@ -126,7 +126,7 @@ pub fn pin_init_derive(input: TokenStream) -> Result<TokenStream> {
         .map(|(f, _)| format_ident!("__C{}", f))
         .collect();
 
-    let this_lifetime: LifetimeDef = syn::parse_str("'__this").unwrap();
+    let this_lifetime = quote!('__this);
     let error_ident = format_ident!("__E");
     let fn_ident = format_ident!("__F");
     let builder_ident = format_ident!("{}Builder", ident);
@@ -402,10 +402,10 @@ fn looks_like_tuple_struct_call(call: &ExprCall) -> bool {
 fn scan_attribute(attrs: &mut Vec<Attribute>) -> Option<bool> {
     let mut ret = None;
     attrs.retain(|a| {
-        if a.path.is_ident("unpin") {
+        if a.path().is_ident("unpin") {
             ret = Some(false);
             false
-        } else if a.path.is_ident("pin") {
+        } else if a.path().is_ident("pin") {
             ret = Some(true);
             false
         } else {


### PR DESCRIPTION
Compiling pin-init fails with this error:

```
error[E0432]: unresolved imports `syn::visit_mut`, `syn::visit_mut`
 --> pin-init-internal/src/pin_init.rs:4:29
  |
4 |     punctuated::Punctuated, visit_mut, visit_mut::VisitMut, Attribute, Data, DeriveInput, Error,
  |                             ^^^^^^^^^  ^^^^^^^^^ could not find `visit_mut` in `syn`
  |                             |
  |                             no `visit_mut` in the root
```

The easiest way to fix it is to use syn 2.0, which requires a few changes.